### PR TITLE
Fix umc-server StatefulSet updateStrategy

### DIFF
--- a/helm/umc-server/templates/statefulset-server.yaml
+++ b/helm/umc-server/templates/statefulset-server.yaml
@@ -17,7 +17,8 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" .) | nindent 4 }}
+  updateStrategy:
+    type: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" .) | nindent 4 }}
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}


### PR DESCRIPTION
Hello,
i just stumbled over this while experimenting with OpenDesk (i originally come from [here](https://gitlab.opencode.de/bmi/opendesk/component-code/crossfunctional/univention/ums-container-umc)).

I assume my fix does what was originally intended, judging by the value referenced.

Compare
```
kubectl explain StatefulSet.spec.strategy
```

vs.
```
kubectl explain StatefulSet.spec.updateStrategy
```

Thanks for making cool free software!